### PR TITLE
Add missing chars on fieldname exclusion to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The form of each alternative is a simple string:
     ALTERNATIVE := FIELDNAME CONDITION VALUE
 
 `FIELDNAME` contains only UTF-8 characters, exclusive of
-! " # $ % & ' ( ) * +, - . / : ;  ? @ [ \ ] ^ _ \` { | } ~ (C's ispunct()).
+! " # $ % & ' ( ) * +, - . / : ; < = > ? @ [ \ ] ^ _ \` { | } ~ (C's ispunct()).
 These can appear inside a `VALUE`, but `&`, `|` and `\\` must be escaped with `\` (escaping is legal for any character, but unnecessary).
 
 


### PR DESCRIPTION
This PR adds the chars  `<` `=` `>` to the `FIELDNAME` exclusion list.